### PR TITLE
Only SetVolume for active AudioSource

### DIFF
--- a/Post tutorial series fixes/AudioManager.cs
+++ b/Post tutorial series fixes/AudioManager.cs
@@ -78,8 +78,7 @@ public class AudioManager : MonoBehaviour {
 			break;
 		}
 
-		musicSources [0].volume = musicVolumePercent * masterVolumePercent;
-		musicSources [1].volume = musicVolumePercent * masterVolumePercent;
+		musicSources[activeMusicSourceIndex].volume = musicVolumePercent * masterVolumePercent;
 
 		PlayerPrefs.SetFloat ("master vol", masterVolumePercent);
 		PlayerPrefs.SetFloat ("sfx vol", sfxVolumePercent);


### PR DESCRIPTION
Make sure we only change the volume from the menu for the active AudioSource, otherwise the music will overlap.